### PR TITLE
1.0.4

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -27,7 +27,7 @@ _bashpack() {
   local prev=${COMP_WORDS[COMP_CWORD-1]}
   
   case ${COMP_CWORD} in
-    1) COMPREPLY=($(compgen -W "update man --current-publication --version --help --self-install --self-update --self-delete" -- ${cur})) ;;
+    1) COMPREPLY=($(compgen -W "update man --test-installation --publication --version --help --self-install --self-update --self-delete" -- ${cur})) ;;
     2)
       case ${prev} in
         update) COMPREPLY=($(compgen -W "--help --assume-yes --ask --when --get-logs" -- ${cur})) ;;

--- a/bashpack.sh
+++ b/bashpack.sh
@@ -239,7 +239,7 @@ COMMAND_UPDATE="$dir_src/update.sh"
 COMMAND_MAN="$dir_src/man.sh"
 COMMAND_SYSTEMD_LOGS="journalctl -e _SYSTEMD_INVOCATION_ID=`systemctl show -p InvocationID --value $file_systemd_update.service`"
 COMMAND_SYSTEMD_STATUS="systemctl status $file_systemd_update.timer"
-
+COMMAND_TEST_INTALLATION="$dir_src/tests.sh"
 
 
 
@@ -607,6 +607,7 @@ case "$1" in
 	-u|--self-update)		update_cli ;;		# Critical option, see the comments at function declaration for more info
 	--self-delete)			delete_all ;;
 	-p|--current-publication)	detect_publication ;;
+	-t|--test-installation)	$COMMAND_TEST_INTALLATION ;;
 	man)					$COMMAND_MAN ;;
 	update)
 		if [[ -z "$2" ]]; then

--- a/bashpack.sh
+++ b/bashpack.sh
@@ -25,7 +25,7 @@
 
 
 
-VERSION="1.0.2"
+VERSION="1.0.3"
 
 NAME="Bashpack"
 NAME_LOWERCASE=$(echo "$NAME" | tr A-Z a-z)

--- a/bashpack.sh
+++ b/bashpack.sh
@@ -25,7 +25,7 @@
 
 
 
-export VERSION="1.0.3"
+export VERSION="1.0.4"
 
 export NAME="Bashpack"
 export NAME_LOWERCASE=$(echo "$NAME" | tr A-Z a-z)

--- a/bashpack.sh
+++ b/bashpack.sh
@@ -73,7 +73,7 @@ else
 		&&		echo " -u, --self-update		update your current $NAME installation to the latest available version on the chosen publication." \
 		&&		echo "     --self-delete		delete $NAME from your system." \
 		&&		echo "     --help   			display this information." \
-		&&		echo " -p, --current-publication	display your current $NAME installation publication stage (main, unstable, dev)." \
+		&&		echo " -p, --publication		display your current $NAME installation publication stage (main, unstable, dev)." \
 		&&		echo "     --version			display version." \
 		&&		echo "" \
 		&&		echo "Commands:" \

--- a/bashpack.sh
+++ b/bashpack.sh
@@ -25,11 +25,11 @@
 
 
 
-VERSION="1.0.3"
+export VERSION="1.0.3"
 
-NAME="Bashpack"
-NAME_LOWERCASE=$(echo "$NAME" | tr A-Z a-z)
-NAME_ALIAS="bp"
+export NAME="Bashpack"
+export NAME_LOWERCASE=$(echo "$NAME" | tr A-Z a-z)
+export NAME_ALIAS="bp"
 
 BASE_URL="https://api.github.com/repos/bashpack-project"
 
@@ -200,7 +200,7 @@ file_systemd_timers=(
 )
 
 file_config=$NAME_LOWERCASE"_config"
-file_current_publication=$dir_config"/.current_production"
+file_current_publication=$dir_config"/.current_publication"
 
 
 
@@ -239,8 +239,8 @@ COMMAND_UPDATE="$dir_src/update.sh"
 COMMAND_MAN="$dir_src/man.sh"
 COMMAND_SYSTEMD_LOGS="journalctl -e _SYSTEMD_INVOCATION_ID=`systemctl show -p InvocationID --value $file_systemd_update.service`"
 COMMAND_SYSTEMD_STATUS="systemctl status $file_systemd_update.timer"
-COMMAND_TEST_INTALLATION="$dir_src/tests.sh"
-
+# COMMAND_TEST_INTALLATION="$dir_src/tests.sh"	# The tests.sh file must be part of the release and cannot be called directly with ./bashpack.sh -t
+COMMAND_TEST_INTALLATION="commands/tests.sh"
 
 
 # Delete the installed command from the system
@@ -606,7 +606,7 @@ case "$1" in
 	-i|--self-install)		install_cli ;;		# Critical option, see the comments at function declaration for more info
 	-u|--self-update)		update_cli ;;		# Critical option, see the comments at function declaration for more info
 	--self-delete)			delete_all ;;
-	-p|--current-publication)	detect_publication ;;
+	-p|--publication)		detect_publication ;;
 	-t|--test-installation)	$COMMAND_TEST_INTALLATION ;;
 	man)					$COMMAND_MAN ;;
 	update)

--- a/commands/tests.sh
+++ b/commands/tests.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+# MIT License
+
+# Copyright (c) 2024 Geoffrey Gontard
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+
+
+# Overwrite relatives paths with their absolutes values to ensure right tests results
+file_config=$dir_config"/"$NAME_LOWERCASE"_config"
+file_systemd_update="$dir_systemd/$NAME_LOWERCASE-updates"
+
+# Creating variables for systemd timers since they are in a list in the main CLI file
+file_systemd_timers_update="$dir_systemd/$file_systemd_update.timer"
+
+# Permit to check if files exist or not
+check_files() {
+
+	local number_exists=0
+	local number_notfound=0
+
+	local directories=(
+		$dir_bin
+		$dir_src
+		$dir_systemd
+		$dir_config
+		$dir_autocompletion
+	)
+
+	local files=(
+		$file_main
+		$file_main_alias
+		$file_autocompletion
+		$file_systemd_update
+		$file_systemd_timers_update
+		$file_current_publication
+		$file_config
+	)
+
+
+	for directory in "${directories[@]}"; do
+		if [ -d $directory ]; then
+			echo "[TEST] EXISTS		-> $directory"
+			number_exists=$(number_exists + 1)
+		else
+			echo "[TEST] NOT FOUND	-> $directory"
+			number_notfound=$(number_notfound + 1)
+		fi
+	done
+
+
+	for file in "${files[@]}"; do
+		if [ -f $file ]; then
+			echo "[TEST] EXISTS		-> $file"
+			number_exists=$(number_exists + 1)
+		else
+			echo "[TEST] NOT FOUND	-> $file"
+			number_notfound=$(number_notfound + 1)
+		fi
+	done
+
+
+	echo ""
+	echo "Exist: $number_exists | Not found: $number_notfound"
+
+}
+
+
+# Properly exit
+exit

--- a/commands/tests.sh
+++ b/commands/tests.sh
@@ -25,65 +25,134 @@
 
 
 
-# Overwrite relatives paths with their absolutes values to ensure right tests results
-file_config=$dir_config"/"$NAME_LOWERCASE"_config"
-file_systemd_update="$dir_systemd/$NAME_LOWERCASE-updates"
+# General information
+# This file permit to test if the current installation is working or not.
+# It must be used within the main CLI file since most of the variables used here are declared in the main CLI file.
 
-# Creating variables for systemd timers since they are in a list in the main CLI file
-file_systemd_timers_update="$dir_systemd/$file_systemd_update.timer"
+
+
+dir_bin="/usr/local/sbin"
+dir_src="/usr/local/src/$NAME_LOWERCASE"
+dir_systemd="/lib/systemd/system"
+dir_config="/etc/$NAME_LOWERCASE"
+if [[ $(exists_command "pkg-config") = "exists" ]]; then
+	dir_autocompletion="$(pkg-config --variable=compatdir bash-completion)"
+else
+	dir_autocompletion="/etc/bash_completion.d"
+fi
+
+
+# "Core"	-> means that the CLI can't be installed, uninstalled or updated without it.
+# "Other"	-> means that the CLI can be installed, uninstalled or updated without it.
+# (the update process must handle a clean installation by deleting or creating right files at right places).
+directories_core=(
+	$dir_bin
+)
+directories_other=(
+	$dir_src
+	$dir_systemd
+	$dir_config
+	$dir_autocompletion
+)
+files_core=(
+	"$dir_bin/$NAME_LOWERCASE"
+	"$dir_bin/bp"
+)
+files_other=(
+	"$dir_autocompletion/$NAME_LOWERCASE"
+	"$dir_systemd/$NAME_LOWERCASE-updates.service"
+	"$dir_systemd/$NAME_LOWERCASE-updates.timer"
+	"$dir_config/.current_publication"
+	"$dir_config/"$NAME_LOWERCASE"_config"
+)
+
+
+
 
 # Permit to check if files exist or not
 check_files() {
 
-	local number_exists=0
-	local number_notfound=0
+	local number_core_found=0
+	local number_core_notfound=0
 
-	local directories=(
-		$dir_bin
-		$dir_src
-		$dir_systemd
-		$dir_config
-		$dir_autocompletion
-	)
-
-	local files=(
-		$file_main
-		$file_main_alias
-		$file_autocompletion
-		$file_systemd_update
-		$file_systemd_timers_update
-		$file_current_publication
-		$file_config
-	)
-
-
-	for directory in "${directories[@]}"; do
+	local number_other_found=0
+	local number_other_notfound=0
+	
+	# Core directories
+	for directory in "${directories_core[@]}"; do
 		if [ -d $directory ]; then
-			echo "[TEST] EXISTS		-> $directory"
-			number_exists=$(number_exists + 1)
+			echo "[dir]  Found		-> $directory"
+			number_core_found=$((number_core_found+1))
 		else
-			echo "[TEST] NOT FOUND	-> $directory"
-			number_notfound=$(number_notfound + 1)
+			echo "[dir]  Not found	-> $directory"
+			number_core_notfound=$((number_core_notfound+1))
+		fi
+	done
+	
+	# Other directories
+	for directory in "${directories_other[@]}"; do
+		if [ -d $directory ]; then
+			echo "[dir]  Found		-> $directory"
+			number_other_found=$((number_other_found+1))
+		else
+			echo "[dir]  Not found	-> $directory"
+			number_other_notfound=$((number_other_notfound+1))
 		fi
 	done
 
-
-	for file in "${files[@]}"; do
+	# Core files
+	for file in "${files_core[@]}"; do
 		if [ -f $file ]; then
-			echo "[TEST] EXISTS		-> $file"
-			number_exists=$(number_exists + 1)
+			echo "[file] Found		-> $file"
+			number_core_found=$((number_core_found+1))
 		else
-			echo "[TEST] NOT FOUND	-> $file"
-			number_notfound=$(number_notfound + 1)
+			echo "[file] Not found	-> $file"
+			number_core_notfound=$((number_core_notfound+1))
 		fi
 	done
+
+	# Other files
+	for file in "${files_other[@]}"; do
+		if [ -f $file ]; then
+			echo "[file] Found		-> $file"
+			number_other_found=$((number_other_found+1))
+		else
+			echo "[file] Not found	-> $file"
+			number_other_notfound=$((number_other_notfound+1))
+		fi
+	done
+
+
+	number_core_total=$((${#directories_core[@]}+${#files_core[@]}))
+	number_other_total=$((${#directories_other[@]}+${#files_other[@]}))
 
 
 	echo ""
-	echo "Exist: $number_exists | Not found: $number_notfound"
+	echo "Core	-> found: $number_core_found/$number_core_total	| not found: $number_core_notfound"
+	echo "Other	-> found: $number_other_found/$number_other_total	| not found: $number_other_notfound"
 
+
+	if [ $number_core_notfound -gt 0 ]; then
+		echo ""
+		echo "Error: missing core file(s). A reinstallation is required (https://github.com/bashpack-project/bashpack?tab=readme-ov-file#quick-start)"
+	elif [ $number_other_notfound -gt 0 ]; then
+		echo ""
+		echo "Error: core file(s) are working, but some features are not working as expected. 'sudo bp -i' should solve the issue (if not, you can open an issue at https://github.com/bashpack-project/bashpack/issues)"
+	else
+		echo ""
+		echo "$NAME is working as expected !"
+	fi
 }
+
+
+
+
+check_files
+
+
 
 
 # Properly exit
 exit
+
+#EOF

--- a/commands/tests.sh
+++ b/commands/tests.sh
@@ -30,6 +30,12 @@
 # It must be used within the main CLI file since most of the variables used here are declared in the main CLI file.
 
 
+# To do :
+#	- Create a test that ensure "bp -i", "bp -u" and "bp --self-delete" is working as expected
+# 	- Create a test in case of "bp" or "bashpack" is not available and make this command useless
+
+
+
 
 dir_bin="/usr/local/sbin"
 dir_src="/usr/local/src/$NAME_LOWERCASE"


### PR DESCRIPTION
New features
- Configuration directory available at /etc/bashpack/
- Publications stages with 3 repositories (main, unstable & dev)
- New command to test installation: bp -t (testing files presence only for now)

Improvements
- Detect if Bashpack is currently in its latest version to avoid new installation at each systemd update